### PR TITLE
Update to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Welcome to Plaid's Tiny Quickstart! This repo contains two folders: **vanilla_js
 To get started, clone the repository, `cd` into one of the folders, and follow the instructions in the corresponding **README**. Enjoy! 
 
 ```
-git clone https://github.com/plaid/tiny-quickstart.git && cd /tiny-quickstart
+git clone https://github.com/plaid/tiny-quickstart.git && cd ./tiny-quickstart
 ```
 
 If you're looking for a more fully-featured quickstart, covering more API endpoints, available in more languages, and with explanations of the underlying flows, see the official [Plaid Quickstart](https://www.plaid.com/docs/quickstart). 


### PR DESCRIPTION
Fix issue where command was trying to find the `tiny-quickstart` repo within the root of a user's system. Now it just looks at the current directly when changing directories.