### PR TITLE
Hosted Link: optional webhook-driven completion + UI/CSS polish

### DIFF
--- a/hosted_link/.env.example
+++ b/hosted_link/.env.example
@@ -6,3 +6,10 @@
 PLAID_CLIENT_ID=
 PLAID_SECRET=
 PLAID_ENV=sandbox
+
+# Optional. If set, the app will register this URL as the webhook for
+# the Link session. The /webhook handler will exchange the public_token
+# delivered via SESSION_FINISHED instead of calling /link/token/get from
+# /complete. Must be a publicly reachable URL — use ngrok or similar
+# during local development.
+PLAID_WEBHOOK_URL=

--- a/hosted_link/README.md
+++ b/hosted_link/README.md
@@ -20,7 +20,7 @@ By default — when no webhook is configured — the server calls `/link/token/g
 
 If you'd rather receive the `public_token` server-to-server, set `PLAID_WEBHOOK_URL` in your **.env** file. The app will register that URL with the Link session, and Plaid will POST a `SESSION_FINISHED` event to it when the flow ends. The handler exchanges the token and the `access_token` becomes available to the user's session on the next request.
 
-In this mode, the `/complete` redirect is purely UX — many production apps don't render Plaid API results on it at all, since the webhook drives backend processing independently of where the user is in their browser.
+In webhook mode, `/complete` does no Plaid work — the webhook handler has already exchanged the `public_token` server-to-server. The redirect just lands the user somewhere after they finish the flow; production apps commonly show a simple "you're all set" page here instead of rendering Plaid API results.
 
 The webhook URL must be publicly reachable, so during local development, expose port 8080 via a tunnel like [ngrok](https://ngrok.com/):
 

--- a/hosted_link/README.md
+++ b/hosted_link/README.md
@@ -83,4 +83,4 @@ If you encounter a **MISSING_FIELDS** error, it's possible you did not properly 
 
 #### The page is blank after returning from Plaid
 
-The home page only displays balance information once `/complete` has successfully exchanged a public token. Open your server logs to confirm the exchange succeeded; common causes are an expired link token or a Sandbox session that exited without linking an account.
+The home page only displays balance information once a `public_token` has been retrieved and exchanged — in `/complete` by default, or in `/webhook` when `PLAID_WEBHOOK_URL` is set. Check the relevant server log. Common causes: an expired link token, or a Sandbox session that exited without linking an account.

--- a/hosted_link/README.md
+++ b/hosted_link/README.md
@@ -14,6 +14,18 @@ Hosted Link is the recommended Link mode when the standard embedded Plaid SDKs a
 - **You don't control the frontend** — embedded/nested integrations like iframes or PSP integrations where rendering responsibility lives elsewhere.
 - **You don't have a customer-facing app or website.** For example, the end user accesses Link via a QR code shown in an in-person retail checkout, or via a link sent by email or SMS.
 
+### Optional: webhook-driven completion
+
+By default, when the user is redirected back to `/complete`, the server calls `/link/token/get` to retrieve the `public_token` and exchange it. If you'd rather receive the `public_token` over a webhook, set `PLAID_WEBHOOK_URL` in your **.env** file. The app will register that URL with the Link session, and the `/webhook` handler will exchange the token when it receives the `SESSION_FINISHED` event. `/complete` then just reads the resulting `access_token` from an in-memory store.
+
+The webhook URL must be publicly reachable, so during local development, expose port 8080 via a tunnel like [ngrok](https://ngrok.com/):
+
+```bash
+ngrok http 8080
+```
+
+Then set `PLAID_WEBHOOK_URL=https://<your-ngrok-subdomain>.ngrok-free.app/webhook` in **.env** and restart the server.
+
 ### Running the app
 
 #### Set up your environment

--- a/hosted_link/README.md
+++ b/hosted_link/README.md
@@ -20,7 +20,7 @@ By default — when no webhook is configured — the server calls `/link/token/g
 
 If you'd rather receive the `public_token` server-to-server, set `PLAID_WEBHOOK_URL` in your **.env** file. The app will register that URL with the Link session, and Plaid will POST a `SESSION_FINISHED` event to it when the flow ends. The handler exchanges the token and the `access_token` becomes available to the user's session on the next request.
 
-In webhook mode, `/complete` does no Plaid work — the webhook handler has already exchanged the `public_token` server-to-server. The redirect just lands the user somewhere after they finish the flow; production apps commonly show a simple "you're all set" page here instead of rendering Plaid API results.
+In webhook mode, `/complete` does no Plaid work — the webhook handler has already exchanged the `public_token` via a webhook. The redirect just lands the user somewhere after they finish the flow; production apps commonly show a simple "you're all set" page here instead of rendering Plaid API results.
 
 The webhook URL must be publicly reachable, so during local development, expose port 8080 via a tunnel like [ngrok](https://ngrok.com/):
 

--- a/hosted_link/README.md
+++ b/hosted_link/README.md
@@ -14,7 +14,7 @@ Hosted Link is the recommended Link mode when the standard embedded Plaid SDKs a
 - **You don't control the frontend** — embedded/nested integrations like iframes or PSP integrations where rendering responsibility lives elsewhere.
 - **You don't have a customer-facing app or website.** For example, the end user accesses Link via a QR code shown in an in-person retail checkout, or via a link sent by email or SMS.
 
-### Optional: webhook-driven completion
+### Optional: receiving the public_token via webhook
 
 By default — when no webhook is configured — the server calls `/link/token/get` from the `/complete` redirect to retrieve the `public_token` and exchange it synchronously.
 

--- a/hosted_link/README.md
+++ b/hosted_link/README.md
@@ -16,7 +16,11 @@ Hosted Link is the recommended Link mode when the standard embedded Plaid SDKs a
 
 ### Optional: webhook-driven completion
 
-By default, when the user is redirected back to `/complete`, the server calls `/link/token/get` to retrieve the `public_token` and exchange it. If you'd rather receive the `public_token` over a webhook, set `PLAID_WEBHOOK_URL` in your **.env** file. The app will register that URL with the Link session, and the `/webhook` handler will exchange the token when it receives the `SESSION_FINISHED` event. `/complete` then just reads the resulting `access_token` from an in-memory store.
+By default — when no webhook is configured — the server calls `/link/token/get` from the `/complete` redirect to retrieve the `public_token` and exchange it synchronously.
+
+If you'd rather receive the `public_token` server-to-server, set `PLAID_WEBHOOK_URL` in your **.env** file. The app will register that URL with the Link session, and Plaid will POST a `SESSION_FINISHED` event to it when the flow ends. The handler exchanges the token and the `access_token` becomes available to the user's session on the next request.
+
+In this mode, the `/complete` redirect is purely UX — many production apps don't render Plaid API results on it at all, since the webhook drives backend processing independently of where the user is in their browser.
 
 The webhook URL must be publicly reachable, so during local development, expose port 8080 via a tunnel like [ngrok](https://ngrok.com/):
 

--- a/hosted_link/index.html
+++ b/hosted_link/index.html
@@ -2,53 +2,7 @@
 <html>
   <head>
     <title>Plaid | Minimal Quickstart (Hosted Link)</title>
-    <style>
-      body {
-        font-family:
-          -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
-        margin: 0;
-        padding: 24px;
-        color: #1a1a1a;
-      }
-      #link-account {
-        background: black;
-        color: white;
-        border: none;
-        border-radius: 6px;
-        height: 44px;
-        padding: 0 20px;
-        font-size: 16px;
-        font-weight: 600;
-        cursor: pointer;
-      }
-      #link-account:hover {
-        background: #222;
-      }
-      #source {
-        margin-top: 16px;
-        font-size: 13px;
-        color: #555;
-      }
-      #source code {
-        background: #eee;
-        padding: 1px 5px;
-        border-radius: 3px;
-        font-size: 12px;
-      }
-      #response {
-        margin-top: 12px;
-        padding: 12px;
-        background: #f6f6f6;
-        border-radius: 6px;
-        font-size: 13px;
-        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-        white-space: pre-wrap;
-        word-break: break-word;
-      }
-      #response:empty {
-        display: none;
-      }
-    </style>
+    <link rel="stylesheet" href="/style.css" />
     <script>
       const startHostedLink = async () => {
         const res = await fetch("/api/create_hosted_link");

--- a/hosted_link/index.html
+++ b/hosted_link/index.html
@@ -28,11 +28,20 @@
           const account = await fetch("/api/is_account_connected");
           const connected = await account.json();
           if (connected.status === true) {
+            renderSource(connected.source);
             getBalance();
             return;
           }
           await new Promise((r) => setTimeout(r, 500));
         }
+      };
+
+      const renderSource = (source) => {
+        const el = document.getElementById("source");
+        el.textContent =
+          source === "webhook"
+            ? "public_token retrieved via SESSION_FINISHED webhook"
+            : "public_token retrieved via /link/token/get";
       };
 
       window.addEventListener("DOMContentLoaded", () => {
@@ -63,6 +72,16 @@
     >
       <strong>Link account</strong>
     </button>
+    <div
+      id="source"
+      style="
+        margin-top: 12px;
+        margin-left: 10px;
+        font-family: system-ui, sans-serif;
+        font-size: 13px;
+        color: #444;
+      "
+    ></div>
     <pre
       id="response"
       style="

--- a/hosted_link/index.html
+++ b/hosted_link/index.html
@@ -19,13 +19,19 @@
         pre.style.background = "#F6F6F6";
       };
 
-      // Check whether account is connected (the server populates the session
-      // when Plaid redirects back to /complete after the Hosted Link flow).
+      // In webhook mode, the SESSION_FINISHED event that carries the
+      // public_token is delivered server-to-server, asynchronously from
+      // this page load. Retry briefly so a webhook arriving just after
+      // the redirect doesn't force the user to refresh.
       const getStatus = async function () {
-        const account = await fetch("/api/is_account_connected");
-        const connected = await account.json();
-        if (connected.status === true) {
-          getBalance();
+        for (let i = 0; i < 6; i++) {
+          const account = await fetch("/api/is_account_connected");
+          const connected = await account.json();
+          if (connected.status === true) {
+            getBalance();
+            return;
+          }
+          await new Promise((r) => setTimeout(r, 500));
         }
       };
 

--- a/hosted_link/index.html
+++ b/hosted_link/index.html
@@ -1,22 +1,69 @@
 <!-- index.html – Launches Plaid's Hosted Link flow and renders balance information after the user returns. -->
 <html>
   <head>
+    <title>Plaid | Minimal Quickstart (Hosted Link)</title>
+    <style>
+      body {
+        font-family:
+          -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+        margin: 0;
+        padding: 24px;
+        color: #1a1a1a;
+      }
+      #link-account {
+        background: black;
+        color: white;
+        border: none;
+        border-radius: 6px;
+        height: 44px;
+        padding: 0 20px;
+        font-size: 16px;
+        font-weight: 600;
+        cursor: pointer;
+      }
+      #link-account:hover {
+        background: #222;
+      }
+      #source {
+        margin-top: 16px;
+        font-size: 13px;
+        color: #555;
+      }
+      #source code {
+        background: #eee;
+        padding: 1px 5px;
+        border-radius: 3px;
+        font-size: 12px;
+      }
+      #response {
+        margin-top: 12px;
+        padding: 12px;
+        background: #f6f6f6;
+        border-radius: 6px;
+        font-size: 13px;
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+        white-space: pre-wrap;
+        word-break: break-word;
+      }
+      #response:empty {
+        display: none;
+      }
+    </style>
     <script>
-      // Request a Hosted Link URL from the server, then send the user there.
       const startHostedLink = async () => {
         const res = await fetch("/api/create_hosted_link");
         const data = await res.json();
         window.location.href = data.hosted_link_url;
       };
 
-      // Retrieves balance information
       const getBalance = async function () {
         const response = await fetch("/api/data", { method: "GET" });
         const data = await response.json();
-
-        const pre = document.getElementById("response");
-        pre.textContent = JSON.stringify(data, null, 2);
-        pre.style.background = "#F6F6F6";
+        document.getElementById("response").textContent = JSON.stringify(
+          data,
+          null,
+          2,
+        );
       };
 
       // In webhook mode, the SESSION_FINISHED event that carries the
@@ -38,10 +85,10 @@
 
       const renderSource = (source) => {
         const el = document.getElementById("source");
-        el.textContent =
+        el.innerHTML =
           source === "webhook"
-            ? "public_token retrieved via SESSION_FINISHED webhook"
-            : "public_token retrieved via /link/token/get";
+            ? "<code>public_token</code> retrieved via <code>SESSION_FINISHED</code> webhook"
+            : "<code>public_token</code> retrieved via <code>/link/token/get</code>";
       };
 
       window.addEventListener("DOMContentLoaded", () => {
@@ -52,47 +99,9 @@
       });
     </script>
   </head>
-  <title>Plaid | Minimal Quickstart (Hosted Link)</title>
   <body>
-    <button
-      type="button"
-      id="link-account"
-      class="btn btn-primary btn-dark btn-lg"
-      style="
-        border: 1px solid black;
-        border-radius: 5px;
-        background: black;
-        height: 48px;
-        width: 155px;
-        margin-top: 5;
-        margin-left: 10;
-        color: white;
-        font-size: 18px;
-      "
-    >
-      <strong>Link account</strong>
-    </button>
-    <div
-      id="source"
-      style="
-        margin-top: 12px;
-        margin-left: 10px;
-        font-family: system-ui, sans-serif;
-        font-size: 13px;
-        color: #444;
-      "
-    ></div>
-    <pre
-      id="response"
-      style="
-        top: 60;
-        margin-left: 10;
-        bottom: 0;
-        position: fixed;
-        overflow-y: scroll;
-        overflow-x: hidden;
-        font-size: 14px;
-      "
-    ></pre>
+    <button type="button" id="link-account">Link account</button>
+    <div id="source"></div>
+    <pre id="response"></pre>
   </body>
 </html>

--- a/hosted_link/server.js
+++ b/hosted_link/server.js
@@ -92,27 +92,21 @@ app.post("/webhook", async (req, res) => {
   res.sendStatus(200);
 });
 
-// After a Hosted Link session, the public_token can be retrieved two ways:
-//   - From the SESSION_FINISHED webhook, server-to-server.
-//   - From /link/token/get, called with the original link_token.
-// Both are valid; pick based on whether your environment can receive
-// webhooks. The browser redirect and the webhook are independent and
-// can arrive in either order.
+// Plaid redirects the user here when the Hosted Link flow ends. When
+// SESSION_FINISHED webhooks are configured, that event is the canonical
+// data path — this redirect is just UX (e.g. a "thanks" page or a
+// bounce back to the app). Many production apps don't render Plaid
+// results on this page at all.
+//
+// Without webhooks, /link/token/get is the synchronous fallback for
+// recovering the public_token from the link session.
 app.get("/complete", async (req, res, next) => {
   const link_token = req.session.link_token;
   if (!link_token) {
     return res.redirect("/");
   }
 
-  let access_token;
-
-  if (WEBHOOK_URL) {
-    for (let i = 0; i < 10 && !access_token; i++) {
-      access_token = webhookAccessTokens.get(link_token);
-      if (!access_token) await new Promise((r) => setTimeout(r, 300));
-    }
-    webhookAccessTokens.delete(link_token);
-  } else {
+  if (!WEBHOOK_URL) {
     const tokenGet = await client.linkTokenGet({ link_token });
     const itemAddResult =
       tokenGet.data.link_sessions?.[0]?.results?.item_add_results?.[0];
@@ -120,14 +114,10 @@ app.get("/complete", async (req, res, next) => {
       const exchangeResponse = await client.itemPublicTokenExchange({
         public_token: itemAddResult.public_token,
       });
-      access_token = exchangeResponse.data.access_token;
+      // FOR DEMO PURPOSES ONLY
+      // Store access_token in DB instead of session storage
+      req.session.access_token = exchangeResponse.data.access_token;
     }
-  }
-
-  if (access_token) {
-    // FOR DEMO PURPOSES ONLY
-    // Store access_token in DB instead of session storage
-    req.session.access_token = access_token;
   }
   res.redirect("/");
 });
@@ -141,9 +131,19 @@ app.get("/api/data", async (req, res, next) => {
   });
 });
 
-// Checks whether the user's account is connected, called
-// in index.html on initial page load
+// Webhooks arrive server-to-server with no inherent session context, so
+// the link_token is the correlation ID we use to associate a
+// SESSION_FINISHED event back to the browser session that initiated the
+// flow. We promote a webhook-delivered access_token into the session
+// here, lazily, the next time the browser asks about its connection.
 app.get("/api/is_account_connected", async (req, res, next) => {
+  if (!req.session.access_token && req.session.link_token) {
+    const promoted = webhookAccessTokens.get(req.session.link_token);
+    if (promoted) {
+      req.session.access_token = promoted;
+      webhookAccessTokens.delete(req.session.link_token);
+    }
+  }
   return req.session.access_token
     ? res.json({ status: true })
     : res.json({ status: false });

--- a/hosted_link/server.js
+++ b/hosted_link/server.js
@@ -52,6 +52,10 @@ app.get("/", async (req, res) => {
   res.sendFile(path.join(__dirname, "index.html"));
 });
 
+app.get("/style.css", async (req, res) => {
+  res.sendFile(path.join(__dirname, "style.css"));
+});
+
 // Setting `hosted_link` on /link/token/create opts the session into the
 // Hosted Link flow; the response then includes a `hosted_link_url` that
 // the user must visit to complete linking. `completion_redirect_uri`

--- a/hosted_link/server.js
+++ b/hosted_link/server.js
@@ -25,9 +25,6 @@ const PORT = process.env.PORT || 8080;
 const COMPLETION_REDIRECT_URI = `http://localhost:${PORT}/complete`;
 const WEBHOOK_URL = process.env.PLAID_WEBHOOK_URL || null;
 
-// In-memory store of access tokens delivered via the SESSION_FINISHED
-// webhook, keyed by link_token. Replace with a real database in production.
-// Only used when PLAID_WEBHOOK_URL is configured.
 const webhookAccessTokens = new Map();
 
 // Configuration for the Plaid client
@@ -49,10 +46,10 @@ app.get("/", async (req, res) => {
   res.sendFile(path.join(__dirname, "index.html"));
 });
 
-// Creates a Link token configured for Hosted Link and returns the
-// Plaid-hosted URL the user should visit. The link_token is stashed
-// in the session so we can retrieve the public_token via
-// /link/token/get when the user returns from the hosted flow.
+// Setting `hosted_link` on /link/token/create opts the session into the
+// Hosted Link flow; the response then includes a `hosted_link_url` that
+// the user must visit to complete linking. `completion_redirect_uri`
+// is where Plaid will send the user once the flow ends.
 app.get("/api/create_hosted_link", async (req, res, next) => {
   const tokenResponse = await client.linkTokenCreate({
     user: { client_user_id: req.sessionID },
@@ -60,10 +57,10 @@ app.get("/api/create_hosted_link", async (req, res, next) => {
     language: "en",
     products: ["auth"],
     country_codes: ["US"],
-    // When PLAID_WEBHOOK_URL is configured, Plaid will POST a
-    // SESSION_FINISHED event to it once the Hosted Link flow ends.
-    // The /webhook handler below uses that event to retrieve the
-    // public_token; otherwise /complete falls back to /link/token/get.
+    // If `webhook` is set, Plaid POSTs lifecycle events for this link
+    // session to that URL. For Hosted Link, the relevant event is
+    // SESSION_FINISHED, which carries the public_tokens for any Items
+    // the user linked.
     ...(WEBHOOK_URL ? { webhook: WEBHOOK_URL } : {}),
     hosted_link: {
       completion_redirect_uri: COMPLETION_REDIRECT_URI,
@@ -73,13 +70,12 @@ app.get("/api/create_hosted_link", async (req, res, next) => {
   res.json({ hosted_link_url: tokenResponse.data.hosted_link_url });
 });
 
-// Receives Plaid webhooks. We only care about LINK / SESSION_FINISHED for
-// this demo: when a Hosted Link session ends successfully, Plaid sends us
-// the public_tokens for any Items that were added. We exchange the first
-// one and stash the resulting access_token in webhookAccessTokens, keyed
-// by link_token, so /complete can pick it up when the user is redirected
-// back. The browser-driven /complete redirect and this server-to-server
-// webhook can arrive in either order, hence the polling in /complete.
+// Plaid POSTs all webhooks to a single URL; the body's `webhook_type` and
+// `webhook_code` identify the event. SESSION_FINISHED (under webhook_type
+// "LINK") fires when a Hosted Link session reaches a terminal state. On a
+// successful session, `public_tokens` holds one public_token per linked
+// Item — exchange them for access_tokens via /item/public_token/exchange,
+// the same way you would for embedded Link.
 app.post("/webhook", async (req, res) => {
   const { webhook_type, webhook_code, link_token, public_tokens } =
     req.body || {};
@@ -96,18 +92,12 @@ app.post("/webhook", async (req, res) => {
   res.sendStatus(200);
 });
 
-// Plaid redirects the user here after the Hosted Link flow finishes.
-// There are two ways to recover the access_token at this point:
-//
-//   1. Webhook path (PLAID_WEBHOOK_URL is configured): the SESSION_FINISHED
-//      webhook handler above has already exchanged the public_token and
-//      written the access_token into webhookAccessTokens. We just read it
-//      out. The webhook can arrive slightly after this redirect, so we
-//      poll the map briefly.
-//
-//   2. linkTokenGet path (no webhook configured): we call /link/token/get
-//      to retrieve the public_token from the link session, then exchange
-//      it for an access_token here.
+// After a Hosted Link session, the public_token can be retrieved two ways:
+//   - From the SESSION_FINISHED webhook, server-to-server.
+//   - From /link/token/get, called with the original link_token.
+// Both are valid; pick based on whether your environment can receive
+// webhooks. The browser redirect and the webhook are independent and
+// can arrive in either order.
 app.get("/complete", async (req, res, next) => {
   const link_token = req.session.link_token;
   if (!link_token) {
@@ -117,7 +107,6 @@ app.get("/complete", async (req, res, next) => {
   let access_token;
 
   if (WEBHOOK_URL) {
-    // Webhook may race the redirect; poll briefly (up to ~3s).
     for (let i = 0; i < 10 && !access_token; i++) {
       access_token = webhookAccessTokens.get(link_token);
       if (!access_token) await new Promise((r) => setTimeout(r, 300));

--- a/hosted_link/server.js
+++ b/hosted_link/server.js
@@ -92,14 +92,12 @@ app.post("/webhook", async (req, res) => {
   res.sendStatus(200);
 });
 
-// Plaid redirects the user here when the Hosted Link flow ends. When
-// SESSION_FINISHED webhooks are configured, that event is the canonical
-// data path — this redirect is just UX (e.g. a "thanks" page or a
-// bounce back to the app). Many production apps don't render Plaid
-// results on this page at all.
-//
-// Without webhooks, /link/token/get is the synchronous fallback for
-// recovering the public_token from the link session.
+// Plaid redirects the user here when the Hosted Link flow ends. If
+// you're using the SESSION_FINISHED webhook to get the public_token,
+// this redirect is just UX — e.g. a "thanks" page or a bounce back
+// to the app. Many production apps don't render Plaid results on
+// this page at all. Otherwise, /link/token/get is used here to
+// retrieve the public_token synchronously from the link session.
 app.get("/complete", async (req, res, next) => {
   const link_token = req.session.link_token;
   if (!link_token) {

--- a/hosted_link/server.js
+++ b/hosted_link/server.js
@@ -2,6 +2,12 @@
 server.js – Configures the Plaid client and uses Express to define routes that drive
 a Hosted Link flow. Unlike embedded Link, the Plaid Link UI is hosted at a Plaid URL,
 so the user is redirected away to complete linking and redirected back to /complete.
+
+There are two ways to retrieve the public_token after a Hosted Link session, and this
+app demonstrates both. The choice is driven by whether PLAID_WEBHOOK_URL is set in the
+.env file: if it is, Plaid sends a SESSION_FINISHED webhook carrying the public_token
+to that URL; if it isn't, the app falls back to /link/token/get. Real apps would
+typically pick one based on whether their environment can receive webhooks.
 */
 
 require("dotenv").config();

--- a/hosted_link/server.js
+++ b/hosted_link/server.js
@@ -94,8 +94,6 @@ app.post("/webhook", async (req, res) => {
     webhook_code === "SESSION_FINISHED" &&
     public_tokens?.length
   ) {
-    // A Hosted Link session can include multiple linked Items;
-    // for simplicity this demo handles only the first one.
     const exchangeResponse = await client.itemPublicTokenExchange({
       public_token: public_tokens[0],
     });
@@ -117,8 +115,6 @@ app.get("/complete", async (req, res, next) => {
   }
 
   if (!WEBHOOK_URL) {
-    // A Hosted Link session can include multiple linked Items;
-    // for simplicity this demo handles only the first one.
     const tokenGet = await client.linkTokenGet({ link_token });
     const itemAddResult =
       tokenGet.data.link_sessions?.[0]?.results?.item_add_results?.[0];

--- a/hosted_link/server.js
+++ b/hosted_link/server.js
@@ -121,6 +121,7 @@ app.get("/complete", async (req, res, next) => {
       // FOR DEMO PURPOSES ONLY
       // Store access_token in DB instead of session storage
       req.session.access_token = exchangeResponse.data.access_token;
+      req.session.access_token_source = "link_token_get";
     }
   }
   res.redirect("/");
@@ -145,11 +146,12 @@ app.get("/api/is_account_connected", async (req, res, next) => {
     const promoted = webhookAccessTokens.get(req.session.link_token);
     if (promoted) {
       req.session.access_token = promoted;
+      req.session.access_token_source = "webhook";
       webhookAccessTokens.delete(req.session.link_token);
     }
   }
   return req.session.access_token
-    ? res.json({ status: true })
+    ? res.json({ status: true, source: req.session.access_token_source })
     : res.json({ status: false });
 });
 

--- a/hosted_link/server.js
+++ b/hosted_link/server.js
@@ -23,6 +23,12 @@ app.use(bodyParser.json());
 
 const PORT = process.env.PORT || 8080;
 const COMPLETION_REDIRECT_URI = `http://localhost:${PORT}/complete`;
+const WEBHOOK_URL = process.env.PLAID_WEBHOOK_URL || null;
+
+// In-memory store of access tokens delivered via the SESSION_FINISHED
+// webhook, keyed by link_token. Replace with a real database in production.
+// Only used when PLAID_WEBHOOK_URL is configured.
+const webhookAccessTokens = new Map();
 
 // Configuration for the Plaid client
 const config = new Configuration({
@@ -54,6 +60,11 @@ app.get("/api/create_hosted_link", async (req, res, next) => {
     language: "en",
     products: ["auth"],
     country_codes: ["US"],
+    // When PLAID_WEBHOOK_URL is configured, Plaid will POST a
+    // SESSION_FINISHED event to it once the Hosted Link flow ends.
+    // The /webhook handler below uses that event to retrieve the
+    // public_token; otherwise /complete falls back to /link/token/get.
+    ...(WEBHOOK_URL ? { webhook: WEBHOOK_URL } : {}),
     hosted_link: {
       completion_redirect_uri: COMPLETION_REDIRECT_URI,
     },
@@ -62,26 +73,72 @@ app.get("/api/create_hosted_link", async (req, res, next) => {
   res.json({ hosted_link_url: tokenResponse.data.hosted_link_url });
 });
 
+// Receives Plaid webhooks. We only care about LINK / SESSION_FINISHED for
+// this demo: when a Hosted Link session ends successfully, Plaid sends us
+// the public_tokens for any Items that were added. We exchange the first
+// one and stash the resulting access_token in webhookAccessTokens, keyed
+// by link_token, so /complete can pick it up when the user is redirected
+// back. The browser-driven /complete redirect and this server-to-server
+// webhook can arrive in either order, hence the polling in /complete.
+app.post("/webhook", async (req, res) => {
+  const { webhook_type, webhook_code, link_token, public_tokens } =
+    req.body || {};
+  if (
+    webhook_type === "LINK" &&
+    webhook_code === "SESSION_FINISHED" &&
+    public_tokens?.length
+  ) {
+    const exchangeResponse = await client.itemPublicTokenExchange({
+      public_token: public_tokens[0],
+    });
+    webhookAccessTokens.set(link_token, exchangeResponse.data.access_token);
+  }
+  res.sendStatus(200);
+});
+
 // Plaid redirects the user here after the Hosted Link flow finishes.
-// We pull the public_token off the link session, exchange it for an
-// access_token, and store it on the session.
+// There are two ways to recover the access_token at this point:
+//
+//   1. Webhook path (PLAID_WEBHOOK_URL is configured): the SESSION_FINISHED
+//      webhook handler above has already exchanged the public_token and
+//      written the access_token into webhookAccessTokens. We just read it
+//      out. The webhook can arrive slightly after this redirect, so we
+//      poll the map briefly.
+//
+//   2. linkTokenGet path (no webhook configured): we call /link/token/get
+//      to retrieve the public_token from the link session, then exchange
+//      it for an access_token here.
 app.get("/complete", async (req, res, next) => {
   const link_token = req.session.link_token;
   if (!link_token) {
     return res.redirect("/");
   }
 
-  const tokenGet = await client.linkTokenGet({ link_token });
-  const itemAddResult =
-    tokenGet.data.link_sessions?.[0]?.results?.item_add_results?.[0];
+  let access_token;
 
-  if (itemAddResult?.public_token) {
-    const exchangeResponse = await client.itemPublicTokenExchange({
-      public_token: itemAddResult.public_token,
-    });
+  if (WEBHOOK_URL) {
+    // Webhook may race the redirect; poll briefly (up to ~3s).
+    for (let i = 0; i < 10 && !access_token; i++) {
+      access_token = webhookAccessTokens.get(link_token);
+      if (!access_token) await new Promise((r) => setTimeout(r, 300));
+    }
+    webhookAccessTokens.delete(link_token);
+  } else {
+    const tokenGet = await client.linkTokenGet({ link_token });
+    const itemAddResult =
+      tokenGet.data.link_sessions?.[0]?.results?.item_add_results?.[0];
+    if (itemAddResult?.public_token) {
+      const exchangeResponse = await client.itemPublicTokenExchange({
+        public_token: itemAddResult.public_token,
+      });
+      access_token = exchangeResponse.data.access_token;
+    }
+  }
+
+  if (access_token) {
     // FOR DEMO PURPOSES ONLY
     // Store access_token in DB instead of session storage
-    req.session.access_token = exchangeResponse.data.access_token;
+    req.session.access_token = access_token;
   }
   res.redirect("/");
 });

--- a/hosted_link/server.js
+++ b/hosted_link/server.js
@@ -94,6 +94,8 @@ app.post("/webhook", async (req, res) => {
     webhook_code === "SESSION_FINISHED" &&
     public_tokens?.length
   ) {
+    // A Hosted Link session can include multiple linked Items;
+    // for simplicity this demo handles only the first one.
     const exchangeResponse = await client.itemPublicTokenExchange({
       public_token: public_tokens[0],
     });
@@ -115,6 +117,8 @@ app.get("/complete", async (req, res, next) => {
   }
 
   if (!WEBHOOK_URL) {
+    // A Hosted Link session can include multiple linked Items;
+    // for simplicity this demo handles only the first one.
     const tokenGet = await client.linkTokenGet({ link_token });
     const itemAddResult =
       tokenGet.data.link_sessions?.[0]?.results?.item_add_results?.[0];

--- a/hosted_link/style.css
+++ b/hosted_link/style.css
@@ -1,0 +1,51 @@
+body {
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif;
+  margin: 0;
+  padding: 24px;
+  color: #1a1a1a;
+}
+
+#link-account {
+  background: black;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  height: 44px;
+  padding: 0 20px;
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+#link-account:hover {
+  background: #222;
+}
+
+#source {
+  margin-top: 16px;
+  font-size: 13px;
+  color: #555;
+}
+
+#source code {
+  background: #eee;
+  padding: 1px 5px;
+  border-radius: 3px;
+  font-size: 12px;
+}
+
+#response {
+  margin-top: 12px;
+  padding: 12px;
+  background: #f6f6f6;
+  border-radius: 6px;
+  font-size: 13px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+#response:empty {
+  display: none;
+}


### PR DESCRIPTION
## Summary

Follow-up work for `hosted_link/` after #42 was merged. None of these commits made it into the merged PR.

- Adds optional webhook-driven completion: if `PLAID_WEBHOOK_URL` is set in `.env`, the app passes it as `webhook` on `linkTokenCreate`; the new `POST /webhook` handler exchanges the `public_token` from `SESSION_FINISHED` and stashes the `access_token` in an in-memory map keyed by `link_token`. `/api/is_account_connected` lazily promotes it into the user's session, using `link_token` as the correlation ID. When `PLAID_WEBHOOK_URL` is unset, `/complete` retains its synchronous `/link/token/get` path.
- `/complete` is no longer a data path in webhook mode — it just redirects to `/`. Many production Hosted Link integrations treat the completion redirect as pure UX.
- UI now surfaces which path produced the `access_token` (`SESSION_FINISHED` webhook vs `/link/token/get`).
- `index.html` layout reworked: extracts a small `style.css`, drops `position: fixed`, and stacks button → source label → JSON response normally.
- Comments retargeted to teach Plaid concepts (what `hosted_link` does on `/link/token/create`, what `SESSION_FINISHED` carries, that `link_token` is the correlation ID for webhook ↔ session) rather than narrate this app's plumbing.

## Test plan

- [x] `cd hosted_link && npm install && npm start` boots on port 8080
- [x] **linkTokenGet path** (`PLAID_WEBHOOK_URL` unset): click **Link account** → complete sandbox flow → home page renders balance with the source label "via /link/token/get"
- [x] **Webhook path** (`PLAID_WEBHOOK_URL` set to an ngrok URL): same flow → home page renders balance with the source label "via SESSION_FINISHED webhook"
- [x] No `position: fixed` overlap on the response area; layout looks reasonable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude Session: f84a3682-0afe-4971-b9a0-1de00494400b