### PR TITLE
Fix dead Node.js install link in quickstart READMEs

### DIFF
--- a/hosted_link/README.md
+++ b/hosted_link/README.md
@@ -34,7 +34,7 @@ Then set `PLAID_WEBHOOK_URL=https://<your-ngrok-subdomain>.ngrok-free.app/webhoo
 
 #### Set up your environment
 
-This app uses the latest stable version of Node. For information on installing Node, see [How to install Node.js](https://nodejs.dev/learn/how-to-install-nodejs).
+This app uses the latest stable version of Node. For information on installing Node, see [How to install Node.js](https://nodejs.org/en/download).
 
 #### Install dependencies
 

--- a/nextjs/README.md
+++ b/nextjs/README.md
@@ -10,7 +10,7 @@ If you're looking for a more fully-featured quickstart, covering more API endpoi
 
 #### Set up your environment
 
-Install [Node.js v16+](https://nodejs.dev/learn/how-to-install-nodejs).
+Install [Node.js v16+](https://nodejs.org/en/download).
 
 [Install `pnpm`](https://pnpm.io/installation) to follow along with these instructions as written.
 

--- a/react/README.md
+++ b/react/README.md
@@ -8,7 +8,7 @@ If you're looking for a more fully-featured quickstart, covering more API endpoi
 
 #### Set up your environment
 
-This app requires Node.js 20 or later. You can use a tool such as [nvm](https://github.com/nvm-sh/nvm) to make sure the app uses the target version of Node. For information on installing Node, see [How to install Node.js](https://nodejs.dev/learn/how-to-install-nodejs).
+This app requires Node.js 20 or later. You can use a tool such as [nvm](https://github.com/nvm-sh/nvm) to make sure the app uses the target version of Node. For information on installing Node, see [How to install Node.js](https://nodejs.org/en/download).
 
 #### Install dependencies
 

--- a/vanilla_js/README.md
+++ b/vanilla_js/README.md
@@ -10,7 +10,7 @@ If you're looking for a more fully-featured quickstart, covering more API endpoi
 
 #### Set up your environment
 
-This project uses Node. For information on installing Node, see [How to install Node.js](https://nodejs.dev/learn/how-to-install-nodejs).
+This project uses Node. For information on installing Node, see [How to install Node.js](https://nodejs.org/en/download).
 
 #### Install dependencies
 

--- a/vanilla_typescript/README.md
+++ b/vanilla_typescript/README.md
@@ -10,7 +10,7 @@ If you're looking for a more fully-featured quickstart, covering more API endpoi
 
 #### Set up your environment
 
-This project uses Node. For information on installing Node, see [How to install Node.js](https://nodejs.dev/learn/how-to-install-nodejs).
+This project uses Node. For information on installing Node, see [How to install Node.js](https://nodejs.org/en/download).
 
 #### Install dependencies
 


### PR DESCRIPTION
`nodejs.dev` was folded into `nodejs.org` and the `/learn/how-to-install-nodejs` path now 404s, so the "install Node.js" link in every quickstart README is dead. Repoints all occurrences to the current Node.js download page (`https://nodejs.org/en/download`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)