### PR TITLE
Correct React Native Node minimum in README

### DIFF
--- a/react_native/README.md
+++ b/react_native/README.md
@@ -16,7 +16,7 @@ Follow the environment setup instructions found in the official React Native doc
 
 #### Install dependencies
 
-Ensure you're using Node 18 or higher; you can run `nvm use` to make sure you are using a compatible version of Node for this project. Next, run `npm install` in the **TinyQuickstartReactNative/** folder.
+Ensure you're using Node 20.19.4 or higher; you can run `nvm use` to make sure you are using a compatible version of Node for this project. Next, run `npm install` in the **TinyQuickstartReactNative/** folder.
 
 Navigate to the **ios/** folder and run `bundle install && pod install` to install all necessary iOS dependencies.
 


### PR DESCRIPTION
`react-native@0.85.3` requires Node `^20.19.4 || ^22.13.0 || ...`, so the React Native quickstart no longer runs on the README’s stated Node 18. Updates the minimum to 20.19.4 (the version pinned in `.nvmrc`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)