### PR TITLE
Fix OAuth redirect handling in vanilla_typescript quickstart

### DIFF
--- a/vanilla_typescript/src/oauth.html
+++ b/vanilla_typescript/src/oauth.html
@@ -1,99 +1,41 @@
-<!-- index.html – Links a sample bank account and renders balance information associated with the account. -->
+<!-- oauth.html – Handles the OAuth redirect. Re-initializes Link with the SAME link_token used to start the flow plus the received redirect URI so Link can resume the OAuth session, then returns to the home page. -->
 <html>
+  <head>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.3/jquery.min.js"></script>
+    <title>Plaid | Minimal Quickstart</title>
+  </head>
+  <body>
+    <script src="https://cdn.plaid.com/link/v2/stable/link-initialize.js"></script>
+    <script>
+      (($) => {
+        // On the OAuth redirect we must re-initialize Link with the original
+        // link_token (stored before the redirect) and pass receivedRedirectUri
+        // so Link can pick up the oauth_state_id and resume where it left off.
+        const linkToken = localStorage.getItem("link_token");
 
-<head>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.3/jquery.min.js"></script>
-  <script src="https://cdn.plaid.com/link/v2/stable/link-initialize.js"></script>
-  <script>
-    (async ($) => {
-      // Grab a Link token to initialize Link
-      const createLinkToken = async () => {
-        const res = await fetch("/api/create_link_token");
-        const data = await res.json();
-        const linkToken = data.link_token;
-        localStorage.setItem("link_token", linkToken);
-        return linkToken;
-      };
-
-      // Initialize Link
-      const handler = Plaid.create({
-        token: await createLinkToken(),
-        onSuccess: async (publicToken, metadata) => {
-          await fetch("/api/exchange_public_token", {
-            method: "POST",
-            body: JSON.stringify({ public_token: publicToken }),
-            headers: {
-              "Content-Type": "application/json",
-            },
-          });
-          await getBalance();
-        },
-        onEvent: (eventName, metadata) => {
-          console.log("Event:", eventName);
-          console.log("Metadata:", metadata);
-        },
-        onExit: (error, metadata) => {
-          console.log(error, metadata);
-        },
-      });
-
-      // Start Link when button is clicked
-      const linkAccountButton = document.getElementById("link-account");
-      linkAccountButton.addEventListener("click", (event) => {
+        const handler = Plaid.create({
+          token: linkToken,
+          receivedRedirectUri: window.location.href,
+          onSuccess: async (publicToken, metadata) => {
+            await fetch("/api/exchange_public_token", {
+              method: "POST",
+              body: JSON.stringify({ public_token: publicToken }),
+              headers: {
+                "Content-Type": "application/json",
+              },
+            });
+            window.location.href = "/";
+          },
+          onEvent: (eventName, metadata) => {
+            console.log("Event:", eventName);
+            console.log("Metadata:", metadata);
+          },
+          onExit: (error, metadata) => {
+            console.log(error, metadata);
+          },
+        });
         handler.open();
-      });
-    })(jQuery);
-
-    // Retrieves balance information
-    const getBalance = async function () {
-      const response = await fetch("/api/data", {
-        method: "GET",
-      });
-      const data = await response.json();
-
-      //Render response data
-      const pre = document.getElementById("response");
-      pre.textContent = JSON.stringify(data, null, 2);
-      pre.style.background = "#F6F6F6";
-    };
-
-    // Check whether account is connected
-    const getStatus = async function () {
-      const account = await fetch("/api/is_account_connected");
-      const connected = await account.json();
-      if (connected.status == true) {
-        getBalance();
-      }
-    };
-
-    getStatus();
-  </script>
-</head>
-<title>Plaid | Minimal Quickstart</title>
-
-<body>
-  <button type="button" id="link-account" class="btn btn-primary btn-dark btn-lg" style="
-        border: 1px solid black;
-        border-radius: 5px;
-        background: black;
-        height: 48px;
-        width: 155px;
-        margin-top: 5; 
-        margin-left: 10;
-        color: white;
-        font-size: 18px;
-      ">
-    <strong>Link account</strong>
-  </button>
-  <pre id="response" style="
-        top: 60;
-        margin-left: 10;
-        bottom: 0;
-        position: fixed;
-        overflow-y: scroll;
-        overflow-x: hidden;
-        font-size: 14px;
-      "></pre>
-</body>
-
+      })(jQuery);
+    </script>
+  </body>
 </html>


### PR DESCRIPTION
`vanilla_typescript/src/oauth.html` was a byte-copy of `index.html` — on the OAuth redirect it fetched a **new** `link_token` and waited for a button click, so Link couldn't resume the in-progress OAuth session and the flow never completed.

Per [Plaid's OAuth guide](https://plaid.com/docs/link/oauth/), the redirect page must re-initialize Link with the **same** `link_token` and pass `receivedRedirectUri`, then open automatically. This rewrites `oauth.html` to do that (matching the correct `vanilla_js` sibling) and returns to `/` on success.

(OAuth setup docs for the web quickstarts, including this one, are consolidated in #57.)