### PR TITLE
Fix misleading client_user_id in nextjs quickstart

### DIFF
--- a/nextjs/src/pages/api/create-link-token.js
+++ b/nextjs/src/pages/api/create-link-token.js
@@ -2,7 +2,7 @@ import { plaidClient } from '../../lib/plaid';
 
 export default async function handler(req, res) {
   const tokenResponse = await plaidClient.linkTokenCreate({
-    user: { client_user_id: process.env.PLAID_CLIENT_ID },
+    user: { client_user_id: 'user-id' },
     client_name: "Plaid's Tiny Quickstart",
     language: 'en',
     products: ['auth'],


### PR DESCRIPTION
The nextjs `create-link-token` route set `user.client_user_id` to `process.env.PLAID_CLIENT_ID`. `client_user_id` is meant to be a per-end-user identifier, not your Plaid client id, so this is semantically wrong and misleading for anyone copying the sample. Replaces it with a simple demo `'user-id'` value (the other tiny-quickstart apps use `req.sessionID`; nextjs uses iron-session with no equivalent, so a stable demo id is the minimal fix).

<!-- Claude Session: 3fd9ad6b-147d-48ee-911d-91f17fd33d29 -->