### PR TITLE
Implement OAuth redirect handling in nextjs quickstart

### DIFF
--- a/nextjs/src/pages/index.jsx
+++ b/nextjs/src/pages/index.jsx
@@ -4,14 +4,23 @@ import { usePlaidLink } from 'react-plaid-link';
 
 export default function PlaidLink() {
   const [token, setToken] = useState(null);
+  const [isOauth, setIsOauth] = useState(false);
 
   useEffect(() => {
+    // On the OAuth redirect, reuse the original link_token (stored before the
+    // redirect) so Link can resume the session instead of starting a new one.
+    if (window.location.href.includes('?oauth_state_id=')) {
+      setToken(localStorage.getItem('link_token'));
+      setIsOauth(true);
+      return;
+    }
     const createLinkToken = async () => {
       const response = await fetch('/api/create-link-token', {
         method: 'POST',
       });
       const { link_token } = await response.json();
       setToken(link_token);
+      localStorage.setItem('link_token', link_token);
     };
     createLinkToken();
   }, []);
@@ -27,10 +36,21 @@ export default function PlaidLink() {
     Router.push('/dash');
   }, []);
 
-  const { open, ready } = usePlaidLink({
-    token,
-    onSuccess,
-  });
+  const config = { token, onSuccess };
+  // On the OAuth redirect, pass the received redirect URI (it carries the
+  // oauth_state_id) so Link can pick the flow back up where it left off.
+  if (isOauth && typeof window !== 'undefined') {
+    config.receivedRedirectUri = window.location.href;
+  }
+
+  const { open, ready } = usePlaidLink(config);
+
+  useEffect(() => {
+    // After an OAuth redirect, automatically reopen Link once it's ready.
+    if (isOauth && ready) {
+      open();
+    }
+  }, [isOauth, ready, open]);
 
   return (
     <button onClick={() => open()} disabled={!ready}>


### PR DESCRIPTION
The nextjs sample passed a `redirect_uri` when creating the Link token but never handled the OAuth return, so linking an OAuth institution could never complete — Link was reinitialized without the original token or `receivedRedirectUri`.

Adds the [documented](https://plaid.com/docs/link/oauth/) resume flow to `index.jsx`, matching the `react` sibling: persist the `link_token`, and on the `?oauth_state_id=` redirect reuse that token, set `receivedRedirectUri`, and auto-open Link once ready. `window` access is guarded so the page still statically pre-renders (verified with `next build`).

(OAuth setup docs for the web quickstarts, including this one, are consolidated in #57.)

<!-- Claude Session: 3fd9ad6b-147d-48ee-911d-91f17fd33d29 -->