### PR TITLE
Document OAuth redirect setup across the web quickstarts

### DIFF
--- a/nextjs/.env.example
+++ b/nextjs/.env.example
@@ -6,3 +6,7 @@
 PLAID_CLIENT_ID=
 PLAID_SECRET=
 PLAID_ENV=sandbox
+
+# OPTIONAL: redirect URI for the OAuth flow — allowlist it in the Plaid Dashboard
+# and set it here. See the README's OAuth section.
+PLAID_SANDBOX_REDIRECT_URI=

--- a/nextjs/README.md
+++ b/nextjs/README.md
@@ -32,6 +32,10 @@ cp .env.example .env
 
 Fill out the contents of the **.env** file with the [client ID and Sandbox secret in your Plaid dashboard](https://dashboard.plaid.com/team/keys). Don't place quotes (`"`) around the credentials (i.e., `PLAID_CLIENT_ID=adn08a280hqdaj0ad`). Use the "Sandbox" secret when setting the `PLAID_SECRET` variable.
 
+#### Configure OAuth (optional)
+
+Many major US banks connect only via OAuth, which this sample already supports via a pop-up (no setup needed). Setting a redirect URI switches to the OAuth redirect flow instead — more robust, because pop-ups fail in in-app browsers (links opened from Mail, Facebook, etc.), which you can't predict, and aren't available when Link's web SDK runs inside a mobile app. To use it, allowlist a redirect URI in the [Plaid Dashboard](https://dashboard.plaid.com/team/api) and set `PLAID_SANDBOX_REDIRECT_URI` in **.env** (use `http://localhost:3000/`). See the [OAuth guide](https://plaid.com/docs/link/oauth/).
+
 #### Start the server
 
 ```bash

--- a/react/.env.example
+++ b/react/.env.example
@@ -6,3 +6,7 @@
 PLAID_CLIENT_ID=
 PLAID_SECRET=
 PLAID_ENV=sandbox
+
+# OPTIONAL: redirect URI for the OAuth flow — allowlist it in the Plaid Dashboard
+# and set it here. See the README's OAuth section.
+PLAID_SANDBOX_REDIRECT_URI=

--- a/react/README.md
+++ b/react/README.md
@@ -28,6 +28,10 @@ cp .env.example .env
 
 Fill out the contents of the **.env** file with the [client ID and Sandbox secret in your Plaid dashboard](https://dashboard.plaid.com/team/keys). Don't place quotes (`"`) around the credentials (i.e., `PLAID_CLIENT_ID=adn08a280hqdaj0ad`). Use the "Sandbox" secret when setting the `PLAID_SECRET` variable.
 
+#### Configure OAuth (optional)
+
+Many major US banks connect only via OAuth, which this sample already supports via a pop-up (no setup needed). Setting a redirect URI switches to the OAuth redirect flow instead — more robust, because pop-ups fail in in-app browsers (links opened from Mail, Facebook, etc.), which you can't predict, and aren't available when Link's web SDK runs inside a mobile app. To use it, allowlist a redirect URI in the [Plaid Dashboard](https://dashboard.plaid.com/team/api) and set `PLAID_SANDBOX_REDIRECT_URI` in **.env** (use `http://localhost:3000/`). See the [OAuth guide](https://plaid.com/docs/link/oauth/).
+
 #### Start the server
 
 ```bash

--- a/vanilla_js/.env.example
+++ b/vanilla_js/.env.example
@@ -6,3 +6,7 @@
 PLAID_CLIENT_ID=
 PLAID_SECRET=
 PLAID_ENV=sandbox
+
+# OPTIONAL: redirect URI for the OAuth flow — allowlist it in the Plaid Dashboard
+# and set it here. See the README's OAuth section.
+PLAID_SANDBOX_REDIRECT_URI=

--- a/vanilla_js/README.md
+++ b/vanilla_js/README.md
@@ -30,6 +30,10 @@ cp .env.example .env
 
 Fill out the contents of the **.env** file with the [client ID and Sandbox secret in your Plaid dashboard](https://dashboard.plaid.com/team/keys). Don't place quotes (`"`) around the credentials (i.e., `PLAID_CLIENT_ID=adn08a280hqdaj0ad`). Use the "Sandbox" secret when setting the `PLAID_SECRET` variable.
 
+#### Configure OAuth (optional)
+
+Many major US banks connect only via OAuth, which this sample already supports via a pop-up (no setup needed). Setting a redirect URI switches to the OAuth redirect flow instead — more robust, because pop-ups fail in in-app browsers (links opened from Mail, Facebook, etc.), which you can't predict, and aren't available when Link's web SDK runs inside a mobile app. To use it, allowlist a redirect URI in the [Plaid Dashboard](https://dashboard.plaid.com/team/api) and set `PLAID_SANDBOX_REDIRECT_URI` in **.env** (use `http://localhost:8080/oauth`). See the [OAuth guide](https://plaid.com/docs/link/oauth/).
+
 #### Start the server
 
 ```bash

--- a/vanilla_typescript/.env.example
+++ b/vanilla_typescript/.env.example
@@ -6,3 +6,7 @@
 PLAID_CLIENT_ID=
 PLAID_SECRET=
 PLAID_ENV=sandbox
+
+# OPTIONAL: redirect URI for the OAuth flow — allowlist it in the Plaid Dashboard
+# and set it here. See the README's OAuth section.
+PLAID_SANDBOX_REDIRECT_URI=

--- a/vanilla_typescript/README.md
+++ b/vanilla_typescript/README.md
@@ -30,6 +30,10 @@ cp .env.example .env
 
 Fill out the contents of the **.env** file with the [client ID and Sandbox secret in your Plaid dashboard](https://dashboard.plaid.com/team/keys). Don't place quotes (`"`) around the credentials (i.e., `PLAID_CLIENT_ID=adn08a280hqdaj0ad`). Use the "Sandbox" secret when setting the `PLAID_SECRET` variable.
 
+#### Configure OAuth (optional)
+
+Many major US banks connect only via OAuth, which this sample already supports via a pop-up (no setup needed). Setting a redirect URI switches to the OAuth redirect flow instead — more robust, because pop-ups fail in in-app browsers (links opened from Mail, Facebook, etc.), which you can't predict, and aren't available when Link's web SDK runs inside a mobile app. To use it, allowlist a redirect URI in the [Plaid Dashboard](https://dashboard.plaid.com/team/api) and set `PLAID_SANDBOX_REDIRECT_URI` in **.env** (use `http://localhost:8080/oauth`). See the [OAuth guide](https://plaid.com/docs/link/oauth/).
+
 #### Start the server
 
 ```bash


### PR DESCRIPTION
All four web quickstarts (`react`, `vanilla_js`, `vanilla_typescript`, `nextjs`) read `PLAID_SANDBOX_REDIRECT_URI`, but none documented it — it was missing from every `.env.example` and no README mentioned OAuth. This adds the var to each `.env.example` and a short "Configure OAuth" section to each README.

The note keeps it accurate for a tiny quickstart: these samples already handle OAuth via a pop-up with no setup; setting a redirect URI switches to the OAuth **redirect flow**, which is more robust because pop-ups fail in in-app browsers (links opened from Mail, Facebook, etc.) and aren't available when Link's web SDK is embedded in a mobile app. Each README gives its own redirect URI (`http://localhost:3000/` for react/nextjs, `http://localhost:8080/oauth` for the vanilla apps).

Docs-only. The OAuth **code** for vanilla_typescript and nextjs lands in #54 and #56 respectively; react and vanilla_js already implement it on `main`.

<!-- Claude Session: 3fd9ad6b-147d-48ee-911d-91f17fd33d29 -->